### PR TITLE
Don't strip lines when parsing beatmaps

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -39,9 +39,6 @@ def parse_beatmap_file(content: str) -> Dict[str, dict]:
     current_section = None
 
     for line in content.splitlines():
-        # this line breaks storyboards
-        # line = line.strip()
-
         if (line.startswith('[') and line.endswith(']')):
             # New section
             current_section = line.removeprefix('[').removesuffix(']')

--- a/utils.py
+++ b/utils.py
@@ -39,7 +39,8 @@ def parse_beatmap_file(content: str) -> Dict[str, dict]:
     current_section = None
 
     for line in content.splitlines():
-        line = line.strip()
+        # this line breaks storyboards
+        # line = line.strip()
 
         if (line.startswith('[') and line.endswith(']')):
             # New section


### PR DESCRIPTION
Stripping spaces from lines breaks storyboards, due to them needing to be indented to properly parse. This PR fixes that.
closes #274 